### PR TITLE
added getEntity by Id method to Engine

### DIFF
--- a/src/ecs/Engine.ts
+++ b/src/ecs/Engine.ts
@@ -46,6 +46,14 @@ export class Engine {
   }
 
   /**
+   * @param id The id of the entity to retrieve
+   * @returns The entity matching the requested id
+   */
+  public getEntity(id: number): Entity | undefined {
+    return this._entityMap.get(id);
+  }
+
+  /**
    * @internal
    */
   public get subscriptions(): ReadonlyArray<Subscription<any>> {


### PR DESCRIPTION
Hello, 
I was trying to implement a system allowing an Entity to follow another by storing this entity ID in a Component.

However, I didn't see any method to retrieve an Entity by its ID from the Engine class, so I added it, using the private Engine `_entityMap`.