### PR TITLE
fix: added missing entity return from addtag

### DIFF
--- a/src/ecs/Entity.ts
+++ b/src/ecs/Entity.ts
@@ -535,11 +535,12 @@ export class Entity implements ReadonlyEntity {
    *  .add(EXHAUSTED)
    * ```
    */
-  public addTag(tag: Tag): void {
+  public addTag(tag: Tag): Entity {
     if (!this._tags.has(tag)) {
       this._tags.add(tag);
       this.dispatchOnComponentAdded(tag);
     }
+    return this;
   }
 
   /**


### PR DESCRIPTION
Hi, I noticed today that the Entity:addTag also doesn't return the entity as it notes in the comment.