### PR TITLE
Possibility to remove entity safely

### DIFF
--- a/src/ecs/Engine.ts
+++ b/src/ecs/Engine.ts
@@ -75,8 +75,10 @@ export class Engine {
    * @see onEntityAdded
    */
   public addEntity(entity: Entity): Engine {
-    if (this._entityMap.has(entity.id)) return this;
-
+    if (this._entityMap.has(entity.id)) {
+      this._removalRequested.delete(entity.id);
+      return this;
+    }
     this._entities.push(entity);
     this._entityMap.set(entity.id, entity);
     this.onEntityAdded.emit(entity);

--- a/tests/unit/system.spec.ts
+++ b/tests/unit/system.spec.ts
@@ -107,7 +107,7 @@ describe('Iterative system', () => {
     expect(onRemoved).toEqual({snapshot: true, entity: false});
   });
 
-  it("Safe entities removal during iteration should not break the iteration ordering", () => {
+  it("Entities safe removal during iteration should not break the iteration ordering", () => {
     class Health {
       public constructor(public value: number) {
       }
@@ -134,6 +134,26 @@ describe('Iterative system', () => {
     }
     engine.update(1);
     expect(engine.entities.length).toBe(0);
+  })
+
+  it.each([true, false])(`Re-adding entities which were removed should work after the engine update cycle`, (safe) => {
+    const engine = new Engine();
+    const query = new QueryBuilder().contains(Position).build();
+    engine.addQuery(query);
+
+    for (let i = 0; i < 5; i++) {
+      engine.addEntity(new Entity().add(new Position()));
+    }
+
+    const entities = query.entities.concat()
+    for (let entity of entities) {
+      engine.removeEntity(entity, safe);
+    }
+    for (let entity of entities) {
+      engine.addEntity(entity);
+    }
+    engine.update(0);
+    expect(engine.entities.length).toBe(5);
   })
 });
 


### PR DESCRIPTION
Now, it's possible to remove entity from the engine safely by passing "true" as the second argument for the `Engine.removeEntity` method. 

```typescript
engine.removeEntity(entity, true)
```

It will allow removing entities from the engine and queries after engine update cycle. 

- This behavior added to the version 4.3.0 and will become default in the next major version release 5.0.0.
- Entity, that was safely removed from the Engine, won't be returned by the "getEntityById" immediately (even if the update cycle is not finished).
